### PR TITLE
Make xbmc.translatePath keep trailing slashes

### DIFF
--- a/xbmc/xbmc.py
+++ b/xbmc/xbmc.py
@@ -182,12 +182,14 @@ def translatePath(url, asURL=False):
 #		print "scheme=%s loc=%s path=%s\nspecial[loc]=%s" % (scheme, loc, path,_special[loc])
 		if scheme == 'special' and loc in _special:
 			return ('file://' if asURL else '') \
-				+ os.path.join(_special[loc], os.path.normpath(path.lstrip('\\/')))
+				+ os.path.join(_special[loc], os.path.normpath(path.lstrip('\\/'))) \
+				+ (os.sep if path.endswith('/') else '')
 		if scheme == 'plugin':
 			dir = xbmcinit.get_addon_path(loc)
 			if dir:
 				return ('file://' if asURL else '') \
-					+ os.path.join(dir, os.path.normpath(path.lstrip('\\/')))
+					+ os.path.join(dir, os.path.normpath(path.lstrip('\\/'))) \
+					+ (os.sep if path.endswith('/') else '')
 	except:
 		pass
 	return url


### PR DESCRIPTION
The original xbmc.translatePath implementation in Kodi 14.2 keeps trailing slashes, but the jumpy implementation doesn't (because os.path.normpath apparently removes trailing path separators). 
With this patch the result has a trailing path separator iff the input has a trailing slash.

Addons that do something like the following will not work correctly with the existing implementation, because the result will end with "somedirsome.file" instead of "somedir/some.file".

``` python
xbmc.translatePath("special://home/somedir/") + "some.file"
```
